### PR TITLE
Compile api

### DIFF
--- a/rabbitmq/pom.xml
+++ b/rabbitmq/pom.xml
@@ -15,7 +15,7 @@
             <groupId>org.selyu.messenger</groupId>
             <artifactId>api</artifactId>
             <version>1.0-SNAPSHOT</version>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.rabbitmq</groupId>

--- a/redis-jedis/pom.xml
+++ b/redis-jedis/pom.xml
@@ -15,7 +15,7 @@
             <groupId>org.selyu.messenger</groupId>
             <artifactId>api</artifactId>
             <version>1.0-SNAPSHOT</version>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>redis.clients</groupId>


### PR DESCRIPTION
Changes the jedis & amqp libraries to compile the API so you don't have to import & shade the api separately 